### PR TITLE
sops: /usr/local/* example

### DIFF
--- a/sops/Containerfile
+++ b/sops/Containerfile
@@ -1,0 +1,10 @@
+# Get RHCOS base image of target cluster `oc adm release info --image-for rhel-coreos`
+# This example uses rhel-coreos image from 4.13.0-rc.2
+FROM quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:d98795f7932441b30bb8bcfbbf05912875383fad1f2b3be08a22ec148d68607e
+
+# This example installs to /usr/local/bin, so to work around this, create a dir behind the symlink
+# After install, move the binary to /usr/bin/ for CLI use.
+RUN mkdir -p /var/usrlocal/bin && \ 
+    rpm -Uvh https://github.com/mozilla/sops/releases/download/v3.7.3/sops-3.7.3-1.x86_64.rpm && \
+    mv /var/usrlocal/bin/sops /usr/bin/sops && \
+    ostree container commit

--- a/sops/README.md
+++ b/sops/README.md
@@ -1,0 +1,13 @@
+# Installing sops
+
+This example was chosen because it installs to a location unsupported by rpm-ostree(/usr/local/)
+
+In this example, we:
+
+- create a folder at the "expected" location behind the symlink
+- Install the package via rpm
+- move the binary to /usr/bin from the temporary install location
+
+More links:
+- About sops: https://github.com/mozilla/sops#sops-secrets-operations
+- RHCOS layering: https://docs.openshift.com/container-platform/4.13/post_installation_configuration/coreos-layering.html#coreos-layering


### PR DESCRIPTION
I initially wrote this for https://issues.redhat.com/browse/MCO-526 as an opt/ package example; however this turned out a little bit different due to it being `/usr/local/` install. I'll work on another example for the `opt/` case, but thought this was worth sharing. 

Container build output:
```
$ podman build -t custom-rhcos -f Containerfile 
STEP 1/2: FROM quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:d98795f7932441b30bb8bcfbbf05912875383fad1f2b3be08a22ec148d68607e
STEP 2/2: RUN mkdir -p /var/usrlocal/bin &&     rpm -Uvh https://github.com/mozilla/sops/releases/download/v3.7.3/sops-3.7.3-1.x86_64.rpm &&     mv /var/usrlocal/bin/sops /usr/bin/sops &&     ostree container commit
Retrieving https://github.com/mozilla/sops/releases/download/v3.7.3/sops-3.7.3-1.x86_64.rpm
Verifying...                          ########################################
Preparing...                          ########################################
Updating / installing...
sops-3.7.3-1                          ########################################
COMMIT custom-rhcos
--> c66fe213ab4
Successfully tagged localhost/custom-rhcos:latest
c66fe213ab47738fe57ee47729a6132641921930ff266dcaec336c9d879ce6c0
```

