### PR TITLE
override-kernel-4.12: Use `rhel-coreos-8`

### DIFF
--- a/override-kernel-4.12/Containerfile
+++ b/override-kernel-4.12/Containerfile
@@ -1,4 +1,4 @@
-# Get RHCOS base image of target cluster `oc adm release info --image-for rhel-coreos`
+# Get RHCOS base image of target cluster `oc adm release info --image-for rhel-coreos-8`
 # This example uses rhel-coreos image from 4.12.11-x86_64
 FROM quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:8187de75b281f1ee2da1d62ad94cf9012c73c9d4d739a9d8ca06e44dd17a29d0
 


### PR DESCRIPTION
As is needed for 4.12.