### PR TITLE
MCO-561: Add hadolint to run on Containerfiles

### DIFF
--- a/libreswan/Containerfile
+++ b/libreswan/Containerfile
@@ -3,7 +3,7 @@
 FROM quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:d98795f7932441b30bb8bcfbbf05912875383fad1f2b3be08a22ec148d68607e
 
 # Install our config file
-ADD my-host-to-host.conf /etc/ipsec.d/
+COPY my-host-to-host.conf /etc/ipsec.d/
 
 # RHEL entitled host is needed here to access RHEL packages
 # Install libreswan as extra RHEL package

--- a/override-kernel-4.12/Containerfile
+++ b/override-kernel-4.12/Containerfile
@@ -6,5 +6,6 @@ FROM quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:8187de75b281f1ee2da1d
 # kernel scripts.
 RUN rpm-ostree cliwrap install-to-root /
 # Replace the kernel, kernel-core and kernel-modules packages.
+# hadolint ignore=SC3009
 RUN rpm-ostree override replace http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/Packages/kernel-{,core-,modules-,modules-extra-}4.18.0-483.el8.x86_64.rpm && \
     ostree container commit

--- a/override-kernel/Containerfile
+++ b/override-kernel/Containerfile
@@ -1,10 +1,12 @@
 # Get RHCOS base image of target cluster `oc adm release info --image-for rhel-coreos`
+# hadolint ignore=DL3006
 FROM quay.io/openshift-release-dev/...
 
 # Enable cliwrap; this is currently required to intercept some command invocations made from
 # kernel scripts.
 RUN rpm-ostree cliwrap install-to-root /
 # Replace the kernel packages.  Note as of RHEL 9.2+, there is a new kernel-modules-core that needs
-# to be replaced.
+# to be replaced
+# hadolint ignore=SC3009
 RUN rpm-ostree override replace https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/kernel-{,core-,modules-,modules-core-,modules-extra-}5.14.0-295.el9.x86_64.rpm && \
     ostree container commit

--- a/scripts/containerfile-lint.sh
+++ b/scripts/containerfile-lint.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -eu
+
+FILES=$(find . -name 'Containerfile*' -o -name 'Dockerfile*')
+
+while read -r file; do
+  echo "Linting: ${file}"
+  # Doesn't support specifying multiple files, see https://github.com/hadolint/hadolint-action/issues/3
+  podman run --rm -i ghcr.io/hadolint/hadolint < "${file}"
+done <<< "${FILES}"


### PR DESCRIPTION
-  This linter will perform sanity checks on Containerfiles.  Follow-up PR in release repo to run the linter on each PRs
-  Also fixed some of the issue that was reported by linter