### PR TITLE
Update FROM lines to GA path

### DIFF
--- a/fish/Containerfile
+++ b/fish/Containerfile
@@ -1,6 +1,6 @@
 # Get RHCOS base image of target cluster `oc adm release info --image-for rhel-coreos`
-# This example uses rhel-coreos image from 4.13.0-rc.2
-FROM quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:d98795f7932441b30bb8bcfbbf05912875383fad1f2b3be08a22ec148d68607e
+# hadolint ignore=DL3006
+FROM quay.io/openshift-release/ocp-release@sha256...
 
 # RHEL entitled host is needed here to access RHEL packages
 # Install fish as third party package from EPEL

--- a/htop/Containerfile
+++ b/htop/Containerfile
@@ -1,6 +1,7 @@
-#Start from your base image(more info at https://docs.openshift.com/container-platform/4.13/post_installation_configuration/coreos-layering.html#coreos-layering)
-#This example uses a RHEL 9.2 image from a 4.13 nightly.
-FROM registry.ci.openshift.org/ocp/4.13-2023-03-19-110337@sha256:42e45dd0ba1be3d2681972d6d38c42008c70ddb8c5a96f1f770a11f9bbfb048f
+# Get RHCOS base image of target cluster `oc adm release info --image-for rhel-coreos`
+# hadolint ignore=DL3006
+FROM quay.io/openshift-release/ocp-release@sha256...
+
 #Enable EPEL (more info at https://docs.fedoraproject.org/en-US/epel/ ) and install htop
 RUN rpm-ostree install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm && \
     rpm-ostree install htop && \

--- a/libreswan/Containerfile
+++ b/libreswan/Containerfile
@@ -1,6 +1,6 @@
 # Get RHCOS base image of target cluster `oc adm release info --image-for rhel-coreos`
-# This example uses rhel-coreos image from 4.13.0-rc.2
-FROM quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:d98795f7932441b30bb8bcfbbf05912875383fad1f2b3be08a22ec148d68607e
+# hadolint ignore=DL3006
+FROM quay.io/openshift-release/ocp-release@sha256...
 
 # Install our config file
 COPY my-host-to-host.conf /etc/ipsec.d/

--- a/override-kernel/Containerfile
+++ b/override-kernel/Containerfile
@@ -1,6 +1,6 @@
 # Get RHCOS base image of target cluster `oc adm release info --image-for rhel-coreos`
 # hadolint ignore=DL3006
-FROM quay.io/openshift-release-dev/...
+FROM quay.io/openshift-release/ocp-release@sha256...
 
 # Enable cliwrap; this is currently required to intercept some command invocations made from
 # kernel scripts.

--- a/sops/Containerfile
+++ b/sops/Containerfile
@@ -1,6 +1,6 @@
 # Get RHCOS base image of target cluster `oc adm release info --image-for rhel-coreos`
-# This example uses rhel-coreos image from 4.13.0-rc.2
-FROM quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:d98795f7932441b30bb8bcfbbf05912875383fad1f2b3be08a22ec148d68607e
+# hadolint ignore=DL3006
+FROM quay.io/openshift-release/ocp-release@sha256...
 
 # This example installs to /usr/local/bin, so to work around this, create a dir behind the symlink
 # After install, move the binary to /usr/bin/ for CLI use.


### PR DESCRIPTION
Updating the `FROM` lines to a GA quay.io path and makes them consistent across all but the override-4.12-kernel example. This also updates the sops and fish examples to RHCOS 4.13 images.