### PR TITLE
/opt/* example: with a minimal go app

### DIFF
--- a/dir-walker/Containerfile
+++ b/dir-walker/Containerfile
@@ -1,0 +1,26 @@
+# Building the example app from source
+# This is a contrived example that traverses through all directories in a given path and returns the largest 10 files. 
+FROM golang:1.19 AS build-stage
+WORKDIR /app
+ADD dir-walker.go Makefile .
+RUN make install DESTDIR=./dir-walker-install && tar -C dir-walker-install -cf dir-walker-install.tar .
+
+# Get RHCOS base image of target cluster `oc adm release info --image-for rhel-coreos`
+# hadolint ignore=DL3006
+FROM quay.io/openshift-release/ocp-release@sha256...
+
+#Drop in the tarball from the build stage. ADD can be used if the package is being directly added from the host and not being built. 
+COPY --from=build-stage /app/dir-walker-install.tar /tmp/dir-walker-install.tar
+
+# This example "installs" to /opt/, so to work around this, first create a dir behind the existing symlink(/opt->/var/opt/)
+# After install, move the binary to /usr/lib/ for CLI use in the future. Then, set up symlink(s) via tmpfiles.d, so the binary & supporting files
+# typically stored in opt can be called in the future.
+
+# Note: The "install" step here is just unrolling the tarball; but it can be replaced by other methods to install a package(rpm-ostree install, rpm)
+# as long as the correct symlinks/directories are set up post install.
+RUN mkdir -p /var/opt && \
+    cd / && tar xf /tmp/dir-walker-install.tar && rm -f /tmp/dir-walker-install.tar && \
+    mv /opt/dir-walker /usr/lib/dir-walker && \
+    echo 'd /var/opt 755 root root -' >> /usr/lib/tmpfiles.d/dir-walker.conf && \
+    echo 'L+ /opt/dir-walker - - - - /usr/lib/dir-walker' >> /usr/lib/tmpfiles.d/dir-walker.conf && \
+    ostree container commit

--- a/dir-walker/Makefile
+++ b/dir-walker/Makefile
@@ -1,0 +1,8 @@
+BINARY_NAME=dir-walker
+
+build:
+	go build -o dir-walker dir-walker.go
+
+clean:
+	go clean
+	rm dir-walker

--- a/dir-walker/Makefile
+++ b/dir-walker/Makefile
@@ -1,8 +1,14 @@
 BINARY_NAME=dir-walker
 
 build:
-	go build -o dir-walker dir-walker.go
+	go build -o ${BINARY_NAME} dir-walker.go
 
 clean:
 	go clean
-	rm dir-walker
+	rm ${BINARY_NAME}
+
+install: build
+	install -D -m 0755 ${BINARY_NAME} $(DESTDIR)/opt/${BINARY_NAME}
+
+run: build
+	./${BINARY_NAME}

--- a/dir-walker/dir-walker.go
+++ b/dir-walker/dir-walker.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// Simple app that walks through all folders in a directory, and lists the files in the order of decreasing size
+
+// Defining constants to convert size units
+const (
+	B  = 1
+	KB = 1024 * B
+	MB = 1024 * KB
+	GB = 1024 * MB
+	TB = 1024 * GB
+)
+
+type filePair struct {
+	path     string
+	fileinfo os.FileInfo
+}
+
+func IsHiddenFile(filename string) bool {
+	return filename[0] == '.'
+}
+
+func IsHiddenDir(path string) bool {
+	return strings.Contains(path, "/.")
+}
+
+func printHumanize(path string, size float64) {
+	if size < KB {
+		fmt.Printf("%s: %.2f B\n", path, size)
+	} else if size > KB && size < MB {
+		fmt.Printf("%s: %.2f KB\n", path, size/float64(KB))
+	} else if size >= MB && size < GB {
+		fmt.Printf("%s: %.2f MB\n", path, size/float64(MB))
+	} else if size >= GB && size < TB {
+		fmt.Printf("%s: %.2f GB\n", path, size/float64(GB))
+	} else {
+		fmt.Printf("%s: %.2f TB\n", path, size/float64(TB))
+	}
+
+}
+func main() {
+
+	pathPtr := flag.String("p", "/", "file path to explore")
+	hiddenPtr := flag.Bool("s", false, "traverse hidden directories & files")
+	limitPtr := flag.Int("c", 10, "line limit")
+
+	flag.Parse()
+
+	var files []filePair
+
+	filepath.Walk(*pathPtr, func(path string, info os.FileInfo, err error) error {
+		if info == nil {
+			//in case file gets "cleaned up" during walk
+			return nil
+		}
+		if (IsHiddenFile(info.Name()) || IsHiddenDir(path)) && !(*hiddenPtr) {
+			//skip hidden file/dir
+			return nil
+		}
+		if info.IsDir() {
+			//skip if we're looking at a dir
+			return nil
+		}
+		files = append(files, filePair{path, info})
+		return nil
+	})
+	sort.Slice(files, func(i, j int) bool {
+		return files[i].fileinfo.Size() > files[j].fileinfo.Size()
+	})
+
+	count := 0
+	for _, file := range files {
+		printHumanize(file.path, float64(file.fileinfo.Size()))
+		count += 1
+		if count == *limitPtr {
+			break
+		}
+	}
+}


### PR DESCRIPTION
Wrote a simple go app that traverses directories. Hopefully, this can serve as an example that "lives" in opt/ (:

Containerfile output:
``` 
$ podman build -t custom-rhcos -f Containerfile
[1/2] STEP 1/4: FROM golang:1.19 AS build-stage
[1/2] STEP 2/4: WORKDIR /app
--> f87ae65802a
[1/2] STEP 3/4: ADD dir-walker.go Makefile .
--> 0a76bdb6765
[1/2] STEP 4/4: RUN make build
go build -o dir-walker dir-walker.go
--> e40346c7691
[2/2] STEP 1/3: FROM quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:d98795f7932441b30bb8bcfbbf05912875383fad1f2b3be08a22ec148d68607e
[2/2] STEP 2/3: COPY --from=build-stage /app/dir-walker /tmp
--> Using cache 163ef084a780993127fbf470b54ea835f682ce1211add3ae5b1828045745109f
--> 163ef084a78
[2/2] STEP 3/3: RUN mkdir -p /var/opt &&     cp /tmp/dir-walker /var/opt/dir-walker &&     mv /var/opt/dir-walker /usr/lib/dir-walker &&     rm /tmp/dir-walker &&     echo 'd /var/opt 755 root root -' >> /usr/lib/tmpfiles.d/dir-walker.conf &&     echo 'L+ /opt/dir-walker - - - - /usr/lib/dir-walker' >> /usr/lib/tmpfiles.d/dir-walker.conf &&     ostree container commit
--> Using cache 0812c486e6b9b917411f5d87d1d683867790411eedb512d837b48b92939bc618
[2/2] COMMIT custom-rhcos
--> 0812c486e6b
Successfully tagged localhost/custom-rhcos:latest
0812c486e6b9b917411f5d87d1d683867790411eedb512d837b48b92939bc618
```
And the sample app output, if you're curious (: 
```
sh-5.1# ./opt/dir-walker -p / -c 10
/proc/kcore: 128.00 TB
/var/lib/containers/storage/overlay/b2c5696278c95c50eb1f78386cd2b8ecdcc9117c82da7d917764baa0ef9e215e/merged/proc/kcore: 128.00 TB
/sysroot/ostree/deploy/rhcos/deploy/3b74d35a783eba1a2b63abc387589e9976de9691f6ff3f908af0923804be2735.0/usr/bin/kube-apiserver: 136.79 MB
/sysroot/ostree/repo/objects/00/cfac26e4e6e833d73c4622bbec1cc24c9201ad09056cacf1d721026d585ee4.file: 136.79 MB
/usr/bin/kube-apiserver: 136.79 MB
/sysroot/ostree/repo/objects/b8/7120bc41a7fd958c7c2b003d350a5a05fc94844ae8cb8df587e76e698d82ee.file: 136.33 MB
/var/lib/containers/storage/overlay/986e0c72d645d5a10678eb6fbf29422338381ec007c157787d112018b1ef8bcf/merged/usr/bin/oc: 136.33 MB
/sysroot/ostree/deploy/rhcos/deploy/3b74d35a783eba1a2b63abc387589e9976de9691f6ff3f908af0923804be2735.0/usr/bin/oc: 136.33 MB
/var/lib/containers/storage/overlay/bc465b464da41fca8daa65ca84e57bf64d1e99272d178a1c46aa20382521a958/merged/usr/bin/oc: 136.33 MB
/var/lib/containers/storage/overlay/8b7813edf80e952ef180f8a0bb604daa344d3e42bcee354c5a84ef6c4a814b1b/merged/usr/bin/oc: 136.33 MB
sh-5.1# ./opt/dir-walker --help    
Usage of ./opt/dir-walker:
  -c int
    	line limit (default 10)
  -p string
    	file path to explore (default "/")
  -s	traverse hidden directories & files
```


