### PR TITLE
override-kernel-4.12: keep base image reference generic

### DIFF
--- a/override-kernel-4.12/Containerfile
+++ b/override-kernel-4.12/Containerfile
@@ -1,6 +1,6 @@
 # Get RHCOS base image of target cluster `oc adm release info --image-for rhel-coreos-8`
-# This example uses rhel-coreos image from 4.12.11-x86_64
-FROM quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:8187de75b281f1ee2da1d62ad94cf9012c73c9d4d739a9d8ca06e44dd17a29d0
+# hadolint ignore=DL3006
+FROM quay.io/openshift-release/ocp-release@sha256...
 
 # Enable cliwrap; this is currently required to intercept some command invocations made from
 # kernel scripts.


### PR DESCRIPTION
To avoid confusion among layering users, let's also keep 4.12 example without referencing to a specific image.