### PR TITLE
MCO-561: use hadolint binary instead of container image

### DIFF
--- a/dir-walker/Containerfile
+++ b/dir-walker/Containerfile
@@ -2,7 +2,7 @@
 # This is a contrived example that traverses through all directories in a given path and returns the largest 10 files. 
 FROM golang:1.19 AS build-stage
 WORKDIR /app
-ADD dir-walker.go Makefile .
+COPY dir-walker.go Makefile ./
 RUN make install DESTDIR=./dir-walker-install && tar -C dir-walker-install -cf dir-walker-install.tar .
 
 # Get RHCOS base image of target cluster `oc adm release info --image-for rhel-coreos`
@@ -18,8 +18,9 @@ COPY --from=build-stage /app/dir-walker-install.tar /tmp/dir-walker-install.tar
 
 # Note: The "install" step here is just unrolling the tarball; but it can be replaced by other methods to install a package(rpm-ostree install, rpm)
 # as long as the correct symlinks/directories are set up post install.
+WORKDIR /
 RUN mkdir -p /var/opt && \
-    cd / && tar xf /tmp/dir-walker-install.tar && rm -f /tmp/dir-walker-install.tar && \
+    tar xf /tmp/dir-walker-install.tar && rm -f /tmp/dir-walker-install.tar && \
     mv /opt/dir-walker /usr/lib/dir-walker && \
     echo 'd /var/opt 755 root root -' >> /usr/lib/tmpfiles.d/dir-walker.conf && \
     echo 'L+ /opt/dir-walker - - - - /usr/lib/dir-walker' >> /usr/lib/tmpfiles.d/dir-walker.conf && \

--- a/scripts/containerfile-lint.sh
+++ b/scripts/containerfile-lint.sh
@@ -2,10 +2,22 @@
 
 set -eu
 
+# Fetch hadolint
+version="2.12.0"
+target="hadolint"
+url="https://github.com/${target}/${target}/releases/download/v${version}/${target}-Linux-x86_64"
+
+WORK_DIR=$(mktemp -d)
+target_path="${WORK_DIR}/${target}"
+trap 'rm -rfv ${WORK_DIR} &>/dev/null' EXIT
+
+curl -L "${url}" -o "${target_path}"
+chmod +x "${target_path}"
+
 FILES=$(find . -name 'Containerfile*' -o -name 'Dockerfile*')
 
 while read -r file; do
   echo "Linting: ${file}"
   # Doesn't support specifying multiple files, see https://github.com/hadolint/hadolint-action/issues/3
-  podman run --rm -i ghcr.io/hadolint/hadolint < "${file}"
+  ${target_path} "${file}"
 done <<< "${FILES}"


### PR DESCRIPTION
Simpler to use in ci as it excludes any further dependency on needing podman. Also, nested container run doesn't go well.