### PR TITLE
OCPBUGS-33598: Fixed rhel-coreos base image pattern.

### DIFF
--- a/dir-walker/Containerfile
+++ b/dir-walker/Containerfile
@@ -7,7 +7,7 @@ RUN make install DESTDIR=./dir-walker-install && tar -C dir-walker-install -cf d
 
 # Get RHCOS base image of target cluster `oc adm release info --image-for rhel-coreos`
 # hadolint ignore=DL3006
-FROM quay.io/openshift-release/ocp-release@sha256...
+FROM quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256...
 
 #Drop in the tarball from the build stage. ADD can be used if the package is being directly added from the host and not being built. 
 COPY --from=build-stage /app/dir-walker-install.tar /tmp/dir-walker-install.tar

--- a/fish/Containerfile
+++ b/fish/Containerfile
@@ -1,6 +1,6 @@
 # Get RHCOS base image of target cluster `oc adm release info --image-for rhel-coreos`
 # hadolint ignore=DL3006
-FROM quay.io/openshift-release/ocp-release@sha256...
+FROM quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256...
 
 # RHEL entitled host is needed here to access RHEL packages
 # Install fish as third party package from EPEL

--- a/htop/Containerfile
+++ b/htop/Containerfile
@@ -1,6 +1,6 @@
 # Get RHCOS base image of target cluster `oc adm release info --image-for rhel-coreos`
 # hadolint ignore=DL3006
-FROM quay.io/openshift-release/ocp-release@sha256...
+FROM quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256...
 
 #Enable EPEL (more info at https://docs.fedoraproject.org/en-US/epel/ ) and install htop
 RUN rpm-ostree install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm && \

--- a/libreswan/Containerfile
+++ b/libreswan/Containerfile
@@ -1,6 +1,6 @@
 # Get RHCOS base image of target cluster `oc adm release info --image-for rhel-coreos`
 # hadolint ignore=DL3006
-FROM quay.io/openshift-release/ocp-release@sha256...
+FROM quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256...
 
 # Install our config file
 COPY my-host-to-host.conf /etc/ipsec.d/

--- a/override-kernel-4.12/Containerfile
+++ b/override-kernel-4.12/Containerfile
@@ -1,6 +1,6 @@
 # Get RHCOS base image of target cluster `oc adm release info --image-for rhel-coreos-8`
 # hadolint ignore=DL3006
-FROM quay.io/openshift-release/ocp-release@sha256...
+FROM quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256...
 
 # Enable cliwrap; this is currently required to intercept some command invocations made from
 # kernel scripts.

--- a/override-kernel/Containerfile
+++ b/override-kernel/Containerfile
@@ -1,6 +1,6 @@
 # Get RHCOS base image of target cluster `oc adm release info --image-for rhel-coreos`
 # hadolint ignore=DL3006
-FROM quay.io/openshift-release/ocp-release@sha256...
+FROM quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256...
 
 # Enable cliwrap; this is currently required to intercept some command invocations made from
 # kernel scripts.

--- a/sops/Containerfile
+++ b/sops/Containerfile
@@ -1,6 +1,6 @@
 # Get RHCOS base image of target cluster `oc adm release info --image-for rhel-coreos`
 # hadolint ignore=DL3006
-FROM quay.io/openshift-release/ocp-release@sha256...
+FROM quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256...
 
 # This example installs to /usr/local/bin, so to work around this, create a dir behind the symlink
 # After install, move the binary to /usr/bin/ for CLI use.


### PR DESCRIPTION
Base image for rhel-coreos (rhel-coreos-8 at the time of writing this) was mistakenly written as
```
quay.io/openshift-release/ocp-release@sha256...
```
Which is the one for release images.

The correct one should be:
```
quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256...
```
This PR fixes this.

This is related to [OCPBUGS-33598](https://issues.redhat.com/browse/OCPBUGS-33598) because our documentation pulls some of its examples from this repo.